### PR TITLE
Add a name element to metadata.rb

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name       "pypiserver"
 maintainer       "Cameron Johnston"
 maintainer_email "cameron@rootdown.net"
 license          "Apache 2.0"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "cameron@rootdown.net"
 license          "Apache 2.0"
 description      "Installs/Configures pypiserver"
 
-version          "0.2.0"
+version          "0.2.1"
 
 %w{git python runit}.each do |cb|
   depends cb


### PR DESCRIPTION
Berkshelf goes apeshit if you let a cookbook without a name into your chef server.
