### PR TITLE
Cookbook name, group write-permissions and fallback-url / stand-alone mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,15 @@ Attributes
 * `version` - the version of pypiserver to install (defaults to 0.6.1)
 * `storage` - the directory path where python modules should be stored (defaults to `/opt/pypi-server/packages`)
 * `user` - the user to run pypiserver under (defaults to `root`)
-* `group` - the group to run pypiserver under (defaults to `root`)
+* `group` - the group to run pypiserver under (defaults to `root`).
+  Also this group has write-permissions on the storage. So they can  use `scp` to copy packages into this directory if they have a login on the server.
 * `python_version` - the version of python interpreter to use for the virtualenv (defaults to `python2.7`)
 * `virtualenv` - the directory path where a virtualenv for the pypiserver should be created (optional, defaults to `/opt/pypi-server/env`)
 * `address` - the ip address to bind to (defaults to 0.0.0.0)
 * `port` - the port to bind to (defaults to 8080)
 * `passwd_file` - the full path to apache-style htpasswd file for securing the pypiserver instance (defaults to nil)
+* `fallback_url` - the pypi server to query when this doesn't know about a package (defaults to 'https://pypi.python.org/simple').
+  When set to `null` (js) aka `nil` (ruby), the pypiserver will not forward requests and serve local packages only.
 
 Usage
 =====

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,4 @@
-default['pypiserver']['version'] = '0.6.1'
+default['pypiserver']['version'] = '1.1.7'
 default['pypiserver']['storage'] = '/opt/pypi-server/packages'
 default['pypiserver']['virtualenv'] = '/opt/pypi-server/env'
 default['pypiserver']['user'] = 'root'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -7,3 +7,4 @@ default['pypiserver']['python_version'] = 'python2.7'
 default['pypiserver']['address'] = "0.0.0.0"
 default['pypiserver']['port'] = 8080
 default['pypiserver']['passwd_file'] = nil
+default['pypiserver']['fallback_url'] = 'https://pypi.python.org/simple'

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "pypiserver"
 maintainer       "Cameron Johnston"
 maintainer_email "cameron@rootdown.net"
 license          "Apache 2.0"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -7,9 +7,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -28,6 +28,7 @@ venv = node['pypiserver']['virtualenv']
 directory node['pypiserver']['storage'] do
   owner node['pypiserver']['user']
   group node['pypiserver']['group']
+  mode 0775
   recursive true
 end
 
@@ -70,5 +71,6 @@ runit_service 'pypiserver' do
           'group' => node['pypiserver']['group'],
           'port' => node['pypiserver']['port'],
           'address' => node['pypiserver']['address'],
-          'passwd_file' => node['pypiserver']['passwd_file'])
+          'passwd_file' => node['pypiserver']['passwd_file'],
+          'fallback_url' => node['pypiserver']['fallback_url'])
 end

--- a/templates/default/sv-pypiserver-run.erb
+++ b/templates/default/sv-pypiserver-run.erb
@@ -1,6 +1,11 @@
 #!/bin/bash
 # TODO make this more WSGI generic
 ARGS='-p <%= @options['port'] %> -i <%= @options['address'] %>'
+<%- if @options['fallback_url'].nil? -%>
+ARGS='$ARGS --disable-fallback'
+<%- else -%>
+ARGS='$ARGS --fallback-url <%= @options['fallback_url'] %>'
+<%- end -%>
 STORAGE='<%= @options['storage'] %>'
 <%- unless @options['passwd_file'].nil? -%>
 PASSWD_FILE='-P <%= @options['passwd_file'] %>'


### PR DESCRIPTION
This has several changes:
- Adds a name to the metadata (berkshelf/ridley complained about it missing).
- Make the packages directory group writable so that group members can upload data per scp.
- Set the fallback_url to https://pypi.python.org/simple by default, if the fallback_url is set to null/nil, no fallback is used and pypiserver works stand-alone serving only packages from the local directory.
